### PR TITLE
Two fixes for errors

### DIFF
--- a/inception_score/model.py
+++ b/inception_score/model.py
@@ -87,7 +87,7 @@ def _init_inception():
                     new_shape.append(None)
                 else:
                     new_shape.append(s)
-            o._shape = tf.TensorShape(new_shape)
+            o.set_shape(tf.TensorShape(new_shape))
     w = sess.graph.get_operation_by_name("softmax/logits/MatMul").inputs[1]
     logits = tf.matmul(tf.squeeze(pool3), w)
     softmax = tf.nn.softmax(logits)

--- a/inception_score/model.py
+++ b/inception_score/model.py
@@ -89,7 +89,7 @@ def _init_inception():
                     new_shape.append(s)
             o.set_shape(tf.TensorShape(new_shape))
     w = sess.graph.get_operation_by_name("softmax/logits/MatMul").inputs[1]
-    logits = tf.matmul(tf.squeeze(pool3), w)
+    logits = tf.matmul(tf.squeeze(pool3, [1, 2]), w)
     softmax = tf.nn.softmax(logits)
 
 if softmax is None:


### PR DESCRIPTION
Fixing two errors that arise when running `inception_score/model.py` with tensorflow 1.6.0, presumably due to bit rot and deprecations in current tensorflow versions.


The first error is
```
ValueError: Tensor._shape cannot be assigned, use Tensor.set_shape instead.
```
Commit a851dc2 addresses this error by replacing _shape with set_shape.


After addressing this error, the second error is
```
ValueError: Shape must be rank 2 but is rank 1 for 'MatMul' (op: 'MatMul') with input shapes: [2048], [2048,1008].
```
Commit dff7439 addresses this error by retaining a singleton dimension in the `squeeze` operation.